### PR TITLE
Allow ramsey/uuid v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "doctrine/doctrine-bundle": "^1.8|^2.0",
     "doctrine/orm": "^2.6|^3.0",
     "doctrine/persistence": "^1.0",
-    "ramsey/uuid": "^3.8",
+    "ramsey/uuid": "^3.8 || ^4",
     "ramsey/uuid-doctrine": "^1.5",
     "symfony/config": "^4.1|^5.0",
     "symfony/dependency-injection": "^4.1|^5.0",


### PR DESCRIPTION
Currently the bundle can't be installed with the latest version of the ramsey/uuid library. I don't think this bundle directly requires the library, so I propose removing it from composer.json.